### PR TITLE
Report serverside errors in register form

### DIFF
--- a/templates/abide_crispy_field.html
+++ b/templates/abide_crispy_field.html
@@ -1,0 +1,50 @@
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    <div id="div_{{ field.auto_id }}" class="holder{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.errors and form_show_errors %} error{% endif %}{% if field|is_checkbox %} checkbox{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">{% spaceless %}
+
+        {% if field.label %}
+            {% if field|is_checkbox %}
+                {% crispy_field field %}
+            {% endif %}
+
+            <label for="{{ field.id_for_label }}" {% if field.field.required %}class="required"{% endif %}>
+                {{ field.label|safe }}{% if field.field.required %}<span class="asterisk">*</span>{% endif %}
+            </label>
+        {% endif %}
+
+        {% if field|is_checkboxselectmultiple %}
+	    {% load l10n %}
+	    <ul>{% for choice in field.field.choices %}<li>
+		<label for="id_{{ field.html_name}}_{{ forloop.counter }}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+		  <input type="checkbox"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}">
+		  {{ choice.1|unlocalize }}
+		</label>
+	      </li>{% endfor %}</ul>
+        {% endif %}
+
+        {% if not field|is_checkbox and not field|is_checkboxselectmultiple %}
+            {% crispy_field field %}
+        {% endif %}
+
+        {% if form_show_errors %}
+            {% for error in field.errors %}
+                <small id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="error serverside">
+                    {{ error }}
+                </small>
+            {% endfor %}
+        {% endif %}
+
+        {% if clientside_error %}
+            <small id="clientside_error_{{ field.auto_id }}" class="error clientside">
+                {{ clientside_error }}
+            </small>
+        {% endif %}
+
+        {% if field.help_text %}
+            <div id="hint_{{ field.auto_id }}" class="hint">{{ field.help_text|safe }}</div>
+        {% endif %}
+    {% endspaceless %}</div>
+{% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -130,7 +130,16 @@
   <script src="{% static "js/vendor/jquery-1.10.2.min.js" %}"></script>
   <script src="{% static "js/foundation/foundation.min.js" %}"></script>
   <script>
-  $(document).foundation();
+    $(document).foundation();
+    $(document).ready(function() {
+      $('.error:has(.serverside.error)')
+      .find('.clientside.error').css('display', 'none').end() // force clientside errors not to be shown yet
+      .find('input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled])').one('focus', function() {
+         $(this).closest('.error:has(.error.serverside)').removeClass('error')
+         .find('.serverside').css('display', 'none').end() // force serverside not to be shown again
+         .find('.clientside').removeAttr('style'); // undo force clientside not to be shown yet
+      })
+    });
   </script>
 
   {% block last_body %}{% endblock %}


### PR DESCRIPTION
Hi Victor,

Here is the PR I promised. Only tested under chromium, sorry for that. Please tell me if anything seems wrong to you. If crispy forms foundation is used in combination with abide on the whole site, it could be interesting to spread the change − carefully.

Also, since I adapted the field template from crispy_forms_foundation and did not change this behaviour, all required fields come with an asterisk. Since all fields are required for registration, maybe would it be better to add a css rule for that, `#register .asterisk { display: none; }` should be sufficient I guess.
